### PR TITLE
Add support for optional "global" profile

### DIFF
--- a/BuffWatch.lua
+++ b/BuffWatch.lua
@@ -151,8 +151,13 @@ function update_text()
   if active_profile == nil then
     return
   end
+
   settings = config.load()
-  display_text = get_inactive_buff_text(active_profile) .. get_inactive_buff_text('global')
+  if active_profile == 'global' then
+    display_text = get_inactive_buff_text('global')
+  else
+    display_text = get_inactive_buff_text(active_profile) .. get_inactive_buff_text('global')
+  end
 
   if settings.show_ok_message and table.length(settings.profiles[active_profile]) and display_text == '' then
     display_text = string.format(' %sBuffs OK', colors.green)


### PR DESCRIPTION
- If present, the "global" profile's inactive buffs will be shown at the end of the active set's inactive buffs
- If the config option `default_to_global_profile` is set to `true`, the "global" profile will be set by default instead of showing nothing